### PR TITLE
Added parameter for cross-fiber stress contribution

### DIFF
--- a/Code/Source/svFSI/ALLFUN.f
+++ b/Code/Source/svFSI/ALLFUN.f
@@ -1309,6 +1309,7 @@
       IF (ALLOCATED(lDmn%stM%Tf%gt%qs)) DEALLOCATE(lDmn%stM%Tf%gt%qs)
       IF (ALLOCATED(lDmn%stM%Tf%gt%r))  DEALLOCATE(lDmn%stM%Tf%gt%r)
       IF (ALLOCATED(lDmn%stM%Tf%gt%i))  DEALLOCATE(lDmn%stM%Tf%gt%i)
+      lDmn%stM%Tf%eta_s = 0._RKIND
 
       ! lDmn%cep
       lDmn%cep%cepType  = cepModel_NA

--- a/Code/Source/svFSI/DISTRIBUTE.f
+++ b/Code/Source/svFSI/DISTRIBUTE.f
@@ -1081,6 +1081,7 @@
          CALL cm%bcast(lStM%Tf%gt%r)
          CALL cm%bcast(lStM%Tf%gt%i)
       END IF
+      CALL cm%bcast(lStM%Tf%eta_s)
 
       RETURN
       END SUBROUTINE DIST_MATCONSTS
@@ -1123,6 +1124,7 @@
             CALL cm%bcast(lEc%Yat%i)
          END IF
       END IF
+      CALL cm%bcast(lEc%eta_s)
 
       RETURN
       END SUBROUTINE DIST_ECMODEL

--- a/Code/Source/svFSI/MATMODELS.f
+++ b/Code/Source/svFSI/MATMODELS.f
@@ -49,7 +49,7 @@
 
       TYPE(stModelType) :: stM
       REAL(KIND=RKIND) :: nd, Kp, J, Ja, J2d, J4d, trE, p, pl, Inv1,
-     2   Inv2, Inv4, Inv6, Inv8, Tfa, IDm(nsd,nsd), C(nsd,nsd),
+     2   Inv2, Inv4, Inv6, Inv8, Tfa, Tsa, IDm(nsd,nsd), C(nsd,nsd),
      3   E(nsd,nsd), Ci(nsd,nsd), Sb(nsd,nsd), CCb(nsd,nsd,nsd,nsd),
      4   PP(nsd,nsd,nsd,nsd), CC(nsd,nsd,nsd,nsd)
       REAL(KIND=RKIND) :: r1, r2, g1, g2, g3, rexp
@@ -71,9 +71,13 @@
 
 !     Fiber-reinforced stress
       CALL GET_FIB_STRESS(stM%Tf, Tfa)
+      Tsa = Tfa*stM%Tf%eta_s
 
 !     Electromechanics coupling - active stress
-      IF (lDmn%ec%astress) Tfa = Tfa + ya
+      IF (lDmn%ec%astress) THEN
+         Tfa = Tfa + ya
+         Tsa = Tsa + ya*lDmn%ec%eta_s
+      END IF
 
 !     Electromechanics coupling - active strain
       Fe   = F
@@ -193,8 +197,9 @@
          g3   = stM%ass * Ess * EXP(stM%bss*Ess*Ess)
          Sb   = 2._RKIND*(g1*IDm + g2*Hff + g3*Hss)
 
-!        Fiber reinforcement/active stress
+!        Fiber reinforcement/active + additional cross-fiber stresses
          Sb   = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+     2             + Tsa*MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
 
          g1   = stM%aff*(1._RKIND + 2._RKIND*stM%bff*Eff*Eff)*
      2      EXP(stM%bff*Eff*Eff)
@@ -258,12 +263,12 @@
          g1   = 4._RKIND*stM%aff*g1*rexp
          CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
 
-!        Sheet-Sheet interaction
+!        Sheet-Sheet interaction + additional cross-fiber stress
          rexp = EXP(stM%bss*Ess*Ess)
          g2   = 2._RKIND*stM%ass*Ess*rexp
          Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
          Hss  = kap*IDm + (1._RKIND-3._RKIND*kap)*Hss
-         S    = S + (g2*Hss)
+         S    = S + (g2*Hss) + (Tsa*MAT_DYADPROD(fl(:,2), fl(:,2), nsd))
 
          g2   = (1._RKIND + (2._RKIND*stM%bss*Ess*Ess))
          g2   = 4._RKIND*stM%ass*g2*rexp
@@ -313,8 +318,9 @@
          CCb = 2._RKIND*TEN_DYADPROD(Sb, Sb, nsd)
          Sb  = Sb * r2
 
-!        Fiber reinforcement/active stress
+!        Fiber reinforcement/active + additional cross-fiber stresses
          Sb  = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+     2            + Tsa*MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
 
          r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
          S   = J2d*Sb - r1*Ci
@@ -392,11 +398,11 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          g1   = 4._RKIND*J4d*stM%aff*g1
          CCb  = CCb + g1*TEN_DYADPROD(Hff, Hff, nsd)
 
-!        Sheet-sheet interaction stress
+!        Sheet-sheet interaction stress + additional cross-fiber stress
          rexp = EXP(stM%bss * Ess * Ess)
          g2   = c4s*Ess*rexp
          g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
-         g2   = 2._RKIND*stM%ass*g2
+         g2   = 2._RKIND*stM%ass*g2 + Tsa
          Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
          Sb   = Sb + g2*Hss
 
@@ -497,11 +503,11 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          g1   = 4._RKIND*stM%aff*g1
          CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
 
-!        Sheet-sheet interaction stress
+!        Sheet-sheet interaction stress + additional cross-fiber stress
          rexp = EXP(stM%bss * Ess * Ess)
          g2   = c4s*Ess*rexp
          g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
-         g2   = 2._RKIND*stM%ass*g2
+         g2   = 2._RKIND*stM%ass*g2 + Tsa
          Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
          S    = S + (g2*Hss)
 
@@ -571,7 +577,7 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
       TYPE(stModelType) :: stM
       REAL(KIND=RKIND) :: nd, J, J2d, J4d, trE, Inv1, Inv2, Inv4, Inv6,
      2   Inv8, Tfa, IDm(nsd,nsd), C(nsd,nsd), E(nsd,nsd), Ci(nsd,nsd),
-     3   Sb(nsd,nsd), CCb(nsd,nsd,nsd,nsd), PP(nsd,nsd,nsd,nsd),
+     3   Tsa, Sb(nsd,nsd), CCb(nsd,nsd,nsd,nsd), PP(nsd,nsd,nsd,nsd),
      4   CC(nsd,nsd,nsd,nsd)
       REAL(KIND=RKIND) :: r1, r2, g1, g2, g3, rexp
       ! Guccione !
@@ -591,9 +597,13 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
 
 !     Fiber-reinforced stress
       CALL GET_FIB_STRESS(stM%Tf, Tfa)
+      Tsa = Tfa*stM%Tf%eta_s
 
 !     Electromechanics coupling - active stress
-      IF (lDmn%ec%astress) Tfa = Tfa + ya
+      IF (lDmn%ec%astress) THEN
+         Tfa = Tfa + ya
+         Tsa = Tsa + ya*lDmn%ec%eta_s
+      END IF
 
 !     Electromechanics coupling - active strain
       Fe   = F
@@ -682,8 +692,9 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          g3   = stM%ass * Ess * EXP(stM%bss*Ess*Ess)
          Sb   = 2._RKIND*(g1*IDm + g2*Hff + g3*Hss)
 
-!        Fiber reinforcement/active stress
+!        Fiber reinforcement/active + additional cross-fiber stresses
          Sb   = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+     2             + Tsa*MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
 
          g1   = stM%aff*(1._RKIND + 2._RKIND*stM%bff*Eff*Eff)*
      2      EXP(stM%bff*Eff*Eff)
@@ -742,12 +753,12 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          g1   = 4._RKIND*stM%aff*g1*rexp
          CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
 
-!        Sheet-Sheet interaction
+!        Sheet-Sheet interaction + additional cross-fiber stress
          rexp = EXP(stM%bss*Ess*Ess)
          g2   = 2._RKIND*stM%ass*Ess*rexp
          Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
          Hss  = kap*IDm + (1._RKIND-3._RKIND*kap)*Hss
-         S    = S + (g2*Hss)
+         S    = S + (g2*Hss) + (Tsa*MAT_DYADPROD(fl(:,2), fl(:,2), nsd))
 
          g2   = (1._RKIND + (2._RKIND*stM%bss*Ess*Ess))
          g2   = 4._RKIND*stM%ass*g2*rexp
@@ -797,8 +808,9 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          CCb = 2._RKIND*TEN_DYADPROD(Sb, Sb, nsd)
          Sb  = Sb * r2
 
-!        Fiber reinforcement/active stress
+!        Fiber reinforcement/active + addtional cross-fiber stresses
          Sb  = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+     2            + Tsa*MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
 
          r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
          S   = J2d*Sb - r1*Ci
@@ -873,11 +885,11 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          g1   = 4._RKIND*J4d*stM%aff*g1
          CCb  = CCb + g1*TEN_DYADPROD(Hff, Hff, nsd)
 
-!        Sheet-sheet interaction stress
+!        Sheet-sheet interaction stress + additional cross-fiber stress
          rexp = EXP(stM%bss * Ess * Ess)
          g2   = c4s*Ess*rexp
          g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
-         g2   = 2._RKIND*stM%ass*g2
+         g2   = 2._RKIND*stM%ass*g2 + Tsa
          Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
          Sb   = Sb + g2*Hss
 
@@ -970,11 +982,11 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          g1   = 4._RKIND*stM%aff*g1
          CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
 
-!        Sheet-sheet interaction stress
+!        Sheet-sheet interaction stress + additional cross-fiber stress
          rexp = EXP(stM%bss * Ess * Ess)
          g2   = c4s*Ess*rexp
          g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
-         g2   = 2._RKIND*stM%ass*g2
+         g2   = 2._RKIND*stM%ass*g2 + Tsa
          Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
          S    = S + (g2*Hss)
 
@@ -1100,10 +1112,11 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
       REAL(KIND=RKIND), INTENT(IN) :: gg_0(2,2), gg_x(2,2), fNa0(2,nfd)
       REAL(KIND=RKIND), INTENT(OUT) :: Sml(3), Dml(3,3)
 
+      INTEGER a, b, iFn
       REAL(KIND=RKIND) :: Jg2i, I1, mu, gi_0(2,2), gi_x(2,2), S(2,2),
-     2   CC(2,2,2,2), SN(2,2), CCN(2,2,2,2), a, b, Inv4, Inv6, Inv8,
-     3   Eff, Ess, Efs, flM(2,2), c4f, c4s, dc4f, dc4s, d1, iFn,
-     4   fl(2,2,nfd), Hfs(2,2), EI1, I1T, g1, g2
+     2   CC(2,2,2,2), SN(2,2), CCN(2,2,2,2), Inv4, Inv6, Inv8, Eff, Ess,
+     3   Efs, flM(2,2), c4f, c4s, dc4f, dc4s, d1, fl(2,2,nfd), Hfs(2,2),
+     4   EI1, g1, g2
       TYPE(stModelType) :: stM
 
       Sml  = 0._RKIND
@@ -1304,8 +1317,7 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
 
       INTEGER(KIND=IKIND) :: itr, i, j, k, l
       REAL(KIND=RKIND) :: Jg2, J2, J23, f13, f23, trC3, C33, kap, mu,
-     2   pJ, plJ, gi_x(2,2), gi_0(3,3), Ci(3,3), S(3,3), CC(3,3,3,3),
-     3   fl(2,2,nfd), iFn
+     2   pJ, plJ, gi_x(2,2), gi_0(3,3), Ci(3,3), S(3,3), CC(3,3,3,3)
       TYPE(stModelType) :: stM
 
       Sml  = 0._RKIND

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -212,6 +212,8 @@
          REAL(KIND=8) :: g = 0._RKIND
 !        Unsteady time-dependent values
          TYPE(fcType) :: gt
+!        Cross-fiber (sheet) stress parameter
+         REAL(KIND=RKIND) :: eta_s = 0._RKIND
       END TYPE fibStrsType
 
 !     Structural domain type
@@ -278,6 +280,8 @@
 !          := activation force for active stress model
 !          := fiber contraction parameter for active strain model
          REAL(KIND=RKIND) :: Ya = 0._RKIND
+!        Cross-fiber stress component for active stress coupling
+         REAL(KIND=RKIND) :: eta_s = 0._RKIND
 !        Unsteady time-dependent values for prescribed fiber-shortening
          TYPE(fcType) :: Yat
       END TYPE eccModelType

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -2485,6 +2485,7 @@ c     2         "can be applied for Neumann boundaries only"
       SELECT CASE (TRIM(ctmp))
       CASE ("active_stress", "stress")
          lDmn%ec%astress = .TRUE.
+         lPtr => list%get(lDmn%ec%eta_s, "Cross-fiber stress parameter")
 
       CASE ("active_strain", "strain")
          lDmn%ec%astrain = .TRUE.
@@ -2786,6 +2787,8 @@ c     2         "can be applied for Neumann boundaries only"
          CASE DEFAULT
             err = "Undefined type of fiber reinforcement stress"
          END SELECT
+         lPtr => lFib%get(lDmn%stM%Tf%eta_s,
+     2      "Cross-fiber stress parameter")
       END IF
 
 !     Check for shell model

--- a/Code/Source/svFSI/SHELLS.f
+++ b/Code/Source/svFSI/SHELLS.f
@@ -976,7 +976,7 @@
      3   Nx(2,eNoN), Nxx(3,eNoN), aCov0(3,2), aCov(3,2), aCnv0(3,2),
      4   aCnv(3,2), r0_xx(2,2,3), r_xx(2,2,3), aa_0(2,2), aa_x(2,2),
      5   bb_0(2,2), bb_x(2,2), Sm(3,2), Dm(3,3,3), Kc(3,3), Nm(3,3),
-     6   Mm(3,3), KNmMm(3,3,2), Bm(3,3,eNoN), Bb(3,3,eNoN), fl(2,2,nFn),
+     6   Mm(3,3), KNmMm(3,3,2), Bm(3,3,eNoN), Bb(3,3,eNoN),
      7   D0Bm(3,3,eNoN), D1Bm(3,3,eNoN), D1Bb(3,3,eNoN), D2Bb(3,3,eNoN),
      8   T1, BmS, BbS, NxSNx, BmDBm, BmDBb, BbDBm, BbDBb, fNa0(2,nFn)
 


### PR DESCRIPTION
The cross-fiber stress parameter adds stress along the sheet or
cross-fiber direction, relevant for cardiac mechanics.

Commit also include removing a few unused variables and declaring loop
variables as integers